### PR TITLE
Fix kexec deprecation warning

### DIFF
--- a/bin/kexec
+++ b/bin/kexec
@@ -26,7 +26,7 @@ get_shell() {
 
   echo -e "\nGetting you a shell in $selected_container...\n"
   # if bash doesn't work, try sh
-  kubectl exec $pod -c $selected_container -ti bash 2>/dev/null || kubectl exec $pod -c $selected_container -ti sh
+  kubectl exec $pod -c $selected_container -ti -- bash 2>/dev/null || kubectl exec $pod -c $selected_container -ti -- sh
   exit 0
   
 }


### PR DESCRIPTION
Currently when you run exec <pod> you are prompted with this warning `kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.` This resolves the error and ensures kexec continues to work going forward.